### PR TITLE
[BugFix] Check non-existent day in codestats response for last 7 days

### DIFF
--- a/codestats_box.py
+++ b/codestats_box.py
@@ -91,7 +91,8 @@ def get_total_xp_line(
         str(datetime.date.today() - datetime.timedelta(days=i)) for i in range(7)
     ]
     last_seven_days_xp = sum(
-        [code_stats_response[CODE_STATS_DATE_KEY][day] for day in last_seven_days]
+        [code_stats_response[CODE_STATS_DATE_KEY][day] for day in last_seven_days 
+            if day in code_stats_response[CODE_STATS_DATE_KEY]]
     )
     total_xp = code_stats_response[CODE_STATS_TOTAL_XP_KEY]
     total_xp_value = ""


### PR DESCRIPTION
GitHub Action was failing in the update gist step due to the method `get_total_xp_lines(...)` since the response from code stats API might not contain data for all the last 7 days.

Please have a look at the latest run [here](https://github.com/karngyan/codestats-box-python/runs/913029077?check_suite_focus=true)

