### PR TITLE
[Claude Code] feat: avoid updating gist if content and title are unchanged

### DIFF
--- a/codestats_box.py
+++ b/codestats_box.py
@@ -212,8 +212,16 @@ def update_gist(title: str, content: str) -> bool:
     gist = Github(access_token).get_gist(gist_id)
     # Works only for single file. Should we clear all files and create new file?
     old_title = list(gist.files.keys())[0]
+    
+    # Check if content has changed to avoid unnecessary updates
+    current_content = gist.files[old_title].content
+    if current_content == content and old_title == title:
+        print(f"No changes detected. Skipping gist update.")
+        return False
+    
     gist.edit(title, {old_title: InputFileContent(content, title)})
     print(f"{title}\n{content}")
+    return True
 
 
 def get_stats() -> str:


### PR DESCRIPTION
Check existing gist content before updating to prevent unnecessary revisions in gist history when content hasn't actually changed.

- Fetch current gist content using GitHub API
- Compare both content and title with new values
- Skip update if identical and log message
- Return boolean to indicate whether update occurred

Fixes #8

Generated with [Claude Code](https://claude.ai/code)